### PR TITLE
first-boot: run initial configuration before serial tty login

### DIFF
--- a/root/etc/init/first-boot.conf
+++ b/root/etc/init/first-boot.conf
@@ -6,7 +6,7 @@
 # Copyright (C) 2012-2014 Nethesis srl
 #
 
-start on starting start-ttys
+start on starting start-ttys and starting serial
 console owner
 task
 


### PR DESCRIPTION
If we wait for VT ttys, we should wait also for serial ttys.
