### PR TITLE
Add ipv6 localhost to local_access_spec

### DIFF
--- a/lib/perl/esmith/NetworksDB.pm
+++ b/lib/perl/esmith/NetworksDB.pm
@@ -133,7 +133,7 @@ list :-)
 sub local_access_spec
 {
     my $self = shift;
-    my @localAccess = ("127.0.0.1", NethServer::TrustedNetworks::list_mask());
+    my @localAccess = ("127.0.0.1", "::1", NethServer::TrustedNetworks::list_mask());
     return wantarray ? @localAccess : "@localAccess";
 }
 


### PR DESCRIPTION
return also ipv6 localhost address

When list of local access is requested, also ipv6 should be returned 

for instance, Tancredi [accepts](https://github.com/nethesis/nethserver-tancredi/blob/24b1bbcfd7a85129e96527bc65c83b0985560744/root/etc/e-smith/templates/etc/httpd/conf.d/tancredi.conf/10base#L15) request from localhost, but ::1 isn't in adress list and if ::1 is in /etc/hosts, requests are rejected